### PR TITLE
Fixing the delete world gui by making sure the other gui buttons to work as intended.

### DIFF
--- a/net/minecraft/src/GuiDeleteWorld.java
+++ b/net/minecraft/src/GuiDeleteWorld.java
@@ -16,8 +16,11 @@ public class GuiDeleteWorld extends GuiSelectWorld {
 	// Closes the delete world gui - retrorandom
 	protected void actionPerformed(GuiButton button) {
 	    if (button.id == 6) {
-	        this.mc.displayGuiScreen(null); 
+	        this.mc.displayGuiScreen(null);
+	        return;
 	    }
+	    
+	    super.actionPerformed(button);
 	}
 	
 	public void selectWorld(int var1) {

--- a/net/minecraft/src/GuiDeleteWorld.java
+++ b/net/minecraft/src/GuiDeleteWorld.java
@@ -12,7 +12,14 @@ public class GuiDeleteWorld extends GuiSelectWorld {
 	public void initButtons() {
 		this.controlList.add(new GuiButton(6, this.width / 2 - 100, this.height / 6 + 168, "Cancel"));
 	}
-
+	
+	// Closes the delete world gui - retrorandom
+	protected void actionPerformed(GuiButton button) {
+	    if (button.id == 6) {
+	        this.mc.displayGuiScreen(null); 
+	    }
+	}
+	
 	public void selectWorld(int var1) {
 		String var2 = this.getSaveName(var1);
 		if(var2 != null) {


### PR DESCRIPTION
I said in the discord 

> and i also changed it from null so it goes back to the select world GUI instead of the main menu GUI
this.mc.displayGuiScreen(new GuiSelectWorld(this));

Unfortunately this caused more problems if you are willing to do this then you can go do it but for my skill level.

When i do `this.mc.displayGuiScreen(new GuiSelectWorld(this));` It goes back to the delete world GUI when you click cancel on the GuiSelectWorld GUI.

 I went back and changed it back to what It was and now It Is all fixed.