### PR TITLE
minor fixes

### DIFF
--- a/net/minecraft/client/Minecraft.java
+++ b/net/minecraft/client/Minecraft.java
@@ -409,6 +409,7 @@ public abstract class Minecraft implements Runnable {
 		}
 
 		System.gc();
+		this.running = false;
 	}
 
 	public void run() {

--- a/net/minecraft/src/GuiMainMenu.java
+++ b/net/minecraft/src/GuiMainMenu.java
@@ -86,12 +86,12 @@ public class GuiMainMenu extends GuiScreen {
 		this.controlList.clear();
 		this.controlList.add(new GuiButton(1, this.width / 2 - 100, this.height / 4 + 40, "Singleplayer"));
 		this.controlList.add(new GuiButton(2, this.width / 2 - 100, this.height / 4 + 40 + 24, "Multiplayer"));
-//		this.controlList.add(new GuiButton(3, this.width / 2 - 100, this.height / 4 + 40 + 24 * 2, "Play tutorial level"));
+		// this.controlList.add(new GuiButton(3, this.width / 2 - 100, this.height / 4 + 40 + 24 * 2, "Play tutorial level"));
 		this.controlList.add(new GuiButton(0, this.width / 2 - 100, this.height / 4 + 40 + 24 * 2, "Options..."));
 		this.controlList.add(new GuiButton(4, this.width / 2 - 100, this.height / 4 + 40 + 24 * 3, "Credits"));
 		this.controlList.add(new GuiButton(5, this.width / 2 - 100, this.height / 4 + 40 + 24 * 4, "Quit"));
 		((GuiButton)this.controlList.get(1)).enabled = false;
-		((GuiButton)this.controlList.get(2)).enabled = false;
+		// ((GuiButton)this.controlList.get(2)).enabled = false;
 		if(this.mc.session == null) {
 			((GuiButton)this.controlList.get(1)).enabled = false;
 		}
@@ -118,7 +118,6 @@ public class GuiMainMenu extends GuiScreen {
 
 		if(button.id == 5) {
 			this.mc.shutdown();
-			this.mc.shutdownMinecraftApplet();
 		}
 
 	}


### PR DESCRIPTION
Fixed options button being disabled,
Fixed linux crash when quitting:
```
Minecraft: Minecraft Alpha Advanced
OS: Linux (amd64) version 6.12.20_1
Java: 1.8.0_332, Void
VM: OpenJDK 64-Bit Server VM (mixed mode), Void
LWJGL: 2.9.4
[failed to get system properties (java.lang.RuntimeException: No OpenGL context found in the current thread.)]

org.lwjgl.LWJGLException: X Error - disp: 0x7ff7140337f0 serial: 3253 error: GLXBadWindow request_code: 152 minor_code: 32
	at org.lwjgl.opengl.LinuxDisplay.globalErrorHandler(LinuxDisplay.java:320)
	at org.lwjgl.opengl.LinuxDisplay.nDestroyWindow(Native Method)
	at org.lwjgl.opengl.LinuxDisplay.destroyWindow(LinuxDisplay.java:592)
	at org.lwjgl.opengl.Display.destroyWindow(Display.java:351)
	at org.lwjgl.opengl.Display.access$400(Display.java:65)
	at org.lwjgl.opengl.Display$5.destroy(Display.java:835)
	at org.lwjgl.opengl.Display.destroy(Display.java:1095)
	at net.minecraft.client.Minecraft.c(Minecraft.java:408)
	at cx.a(GuiMainMenu.java:121)
	at bh.a(SourceFile:69)
	at bh.e(SourceFile:115)
	at bh.d(SourceFile:103)
	at net.minecraft.client.Minecraft.i(Minecraft.java:821)
	at net.minecraft.client.Minecraft.run(Minecraft.java:449)
	at java.lang.Thread.run(Thread.java:750)
```