### PR TITLE
Fixed FOV/Music Delay Sliders

### DIFF
--- a/net/minecraft/src/EntityRenderer.java
+++ b/net/minecraft/src/EntityRenderer.java
@@ -230,13 +230,17 @@ public class EntityRenderer {
 
 	private float getFOVModifier(float ticks, boolean hand) {
 		EntityPlayerSP player = this.mc.thePlayer;
-		float fov;
-		if (!hand && this.mc.options != null) {
+		// float fov;
+
+		float fov = (mc.options.fov - 0.5F) * 80F + 70F;
+
+		/*if (!hand && this.mc.options != null) {
 			fov = this.mc.options.fov;
 		}
 		else {
 			fov = 70.0F;
-		}
+		}*/
+
 		if(player.isInsideOfMaterial(Material.water)) {
 			fov = fov - 10.0F;
 		}

--- a/net/minecraft/src/GameSettings.java
+++ b/net/minecraft/src/GameSettings.java
@@ -30,8 +30,8 @@ public class GameSettings {
 	public float musicVolume = 1.0F;
 	public float soundVolume = 1.0F;
 	public float mouseSensitivity = 0.5F;
-	public float fov = 70.0F;
-	public int musicDelay = 600;
+	public float fov = 0.5F;					// Sliders are between 0.0-1.0, and the variables that modify them should be too
+	public float musicDelay = 0.5F;	
 	public boolean invertMouse = false;
 	public int renderDistance = 0;
 	public boolean viewBobbing = true;
@@ -123,10 +123,12 @@ public class GameSettings {
 				this.mouseSensitivity = value;
 				break;
 			case MUSICDELAY:
-				this.musicDelay = (int) (value * 600 + 1);
+				// this.musicDelay = (int) (value * 600 + 1);
+				this.musicDelay = value;
 				break;
 			case FOV:
-				this.fov = value * 100 + 1;
+				// this.fov = value * 100 + 1;
+				this.fov = value;
 		}
 		this.saveOptions();
 	}
@@ -157,9 +159,9 @@ public class GameSettings {
 				this.fancyGraphics = !this.fancyGraphics;
 				this.mc.renderGlobal.loadRenderers();
 				break;
-			case MUSICDELAY:
+			/*case MUSICDELAY:
 				this.musicDelay = (int)value;
-				break;
+				break;*/
 			case DARKMODE:
 				this.darkMode = !this.darkMode;
 				break;
@@ -187,11 +189,15 @@ public class GameSettings {
 			case MUSICVOLUME:
 			case SOUNDVOLUME:
 			case MOUSESENSITIVITY:
-				return 1;
+
 			case MUSICDELAY:
+			case FOV:
+				return 1;
+			/*case MUSICDELAY:
 				return 601;
 			case FOV:
-				return 101;
+				// return 101;
+				return 110;*/
 			default:
 				return 0;
 		}
@@ -238,9 +244,11 @@ public class GameSettings {
 			case FANCYGRAPHICS:
 				return "Graphics: " + (this.fancyGraphics ? "FANCY" : "FAST");
 			case MUSICDELAY:
-        return "Music delay: " + this.musicDelay + " seconds";
+				int actualMusicDelay = (int)((this.musicDelay * 600 + 1));
+        		return "Music delay: " + actualMusicDelay + " seconds";
 			case FOV:
-				return "FOV: " + (int)(this.fov);
+				int actualFoV = (int)((this.fov - 0.5F) * 80F + 70F);
+				return "FOV: " + actualFoV;
 			case DARKMODE:
 				return "Dark mode: " + (this.darkMode ? "ON" : "OFF");
 		}
@@ -296,10 +304,12 @@ public class GameSettings {
 						this.fancyGraphics = settingKeyValue[1].equals("true");
 						break;
 					case "musicDelay":
-						this.musicDelay = Integer.parseInt(settingKeyValue[1]);
+						this.musicDelay = this.parseFloat(settingKeyValue[1]);
+						this.musicDelay = this.musicDelay < 0.0F || this.musicDelay > 1.0F ? 0.5F : this.musicDelay;	// Overflow glitch
 						break;
 					case "FOV":
 						this.fov = this.parseFloat(settingKeyValue[1]);
+						this.fov = this.fov < 0.0F || this.fov > 1.0F ? 0.5F : this.fov;	// Overflow glitch
 						break;
 					case "darkMode":
 						this.darkMode = settingKeyValue[1].equals("true");

--- a/net/minecraft/src/GuiMainMenu.java
+++ b/net/minecraft/src/GuiMainMenu.java
@@ -180,7 +180,10 @@ public class GuiMainMenu extends GuiScreen {
 		if(sm != null) {
 			if(!sm.sndSystem.playing("BgMusic") && !sm.sndSystem.playing("streaming")) {
 				SoundPoolEntry entry = sm.soundPoolMusic.getRandomSound();
-				sm.ticksBeforeMusic = this.rand.nextInt(sm.options.musicDelay * 20) + sm.options.musicDelay * 20;
+
+				int actualMusicDelay = (int)((sm.options.musicDelay * 600 + 1));
+
+				sm.ticksBeforeMusic = this.rand.nextInt(actualMusicDelay * 20) + actualMusicDelay * 20;
 				if(entry != null) {
 					sm.sndSystem.backgroundMusic("BgMusic", entry.soundUrl, entry.soundName, false);
 					sm.sndSystem.setVolume("BgMusic", sm.options.musicVolume);

--- a/net/minecraft/src/SoundManager.java
+++ b/net/minecraft/src/SoundManager.java
@@ -58,7 +58,10 @@ public class SoundManager {
 
 		if(this.options.musicVolume == 0.0F) {
 			sndSystem.stop("BgMusic");
-			this.ticksBeforeMusic = this.rand.nextInt(options.musicDelay * 20) + options.musicDelay * 20;
+
+			int actualMusicDelay = (int)((this.options.musicDelay * 600 + 1));
+
+			this.ticksBeforeMusic = this.rand.nextInt(actualMusicDelay * 20) + actualMusicDelay * 20;
 		} else {
 			sndSystem.setVolume("BgMusic", this.options.musicVolume);
 		}
@@ -85,8 +88,10 @@ public class SoundManager {
 	}
 
 	public void playRandomMusicIfReady() {
-		if (this.ticksBeforeMusic > options.musicDelay * 40) {
-			this.ticksBeforeMusic = this.rand.nextInt(options.musicDelay * 20) + options.musicDelay * 20;
+		int actualMusicDelay = (int)((this.options.musicDelay * 600 + 1));
+		
+		if (this.ticksBeforeMusic > actualMusicDelay * 40) {
+			this.ticksBeforeMusic = this.rand.nextInt(actualMusicDelay * 20) + actualMusicDelay * 20;
 		}
 		if(loaded && this.options.musicVolume != 0.0F) {
 			if(!sndSystem.playing("BgMusic") && !sndSystem.playing("streaming")) {
@@ -98,7 +103,7 @@ public class SoundManager {
 
 				SoundPoolEntry music = this.soundPoolMusic.getRandomSound();
 				if(music != null) {
-					this.ticksBeforeMusic = this.rand.nextInt(options.musicDelay * 20) + options.musicDelay * 20;
+					this.ticksBeforeMusic = this.rand.nextInt(actualMusicDelay * 20) + actualMusicDelay * 20;
 					sndSystem.backgroundMusic("BgMusic", music.soundUrl, music.soundName, false);
 					sndSystem.setVolume("BgMusic", this.options.musicVolume);
 					sndSystem.play("BgMusic");


### PR DESCRIPTION
The sliders were bugged and trying to display numbers above 1.0 in version 1.5.1. The slider values are between 0.0-1.0, and beyond that will break and display weirdly, so this should fix it. Also changed FOV to be between 30 degrees and 110 degrees as in modern Minecraft